### PR TITLE
Remove backslash in REGEX_SPECIAL password to prevent error in json

### DIFF
--- a/PasswordGenerator.NetStandard/PasswordGenerator.NetStandard/PasswordGenerator.cs
+++ b/PasswordGenerator.NetStandard/PasswordGenerator.NetStandard/PasswordGenerator.cs
@@ -151,7 +151,7 @@ public class PasswordGenerator
         const string REGEX_LOWERCASE = @"[a-z]";
         const string REGEX_UPPERCASE = @"[A-Z]";
         const string REGEX_NUMERIC = @"[\d]";
-        const string REGEX_SPECIAL = @"([!#$%&*@\\])+";
+        const string REGEX_SPECIAL = @"([!#$%&*@])+";
 
         bool lowerCaseIsValid = !settings.IncludeLowercase || (settings.IncludeLowercase && Regex.IsMatch(password, REGEX_LOWERCASE));
         bool upperCaseIsValid = !settings.IncludeUppercase || (settings.IncludeUppercase && Regex.IsMatch(password, REGEX_UPPERCASE));


### PR DESCRIPTION
Remove backslash in REGEX_SPECIAL password because backslash will cause unexpected format json error when posting to web api server