### PR TITLE
Fix package configuration

### DIFF
--- a/PasswordGenerator.NetStandard/PasswordGenerator.NetStandard/PasswordGenerator.NetStandard.csproj
+++ b/PasswordGenerator.NetStandard/PasswordGenerator.NetStandard/PasswordGenerator.NetStandard.csproj
@@ -8,11 +8,11 @@
     <AssemblyName>PasswordGenerator.NetStandard</AssemblyName>
     <PackageId>PasswordGenerator.NetStandard</PackageId>
     <PackageTags>PasswordGenerator</PackageTags>
-    <PackageProjectUrl>https://github.com/trenoncourt/HtmlAgilityPack.CssSelectors.NetCore</PackageProjectUrl>
-    <NetStandardImplicitPackageVersion>1.0.0</NetStandardImplicitPackageVersion>
+    <PackageProjectUrl>https://github.com/trenoncourt/PasswordGenerator.NetStandard</PackageProjectUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
The package configuration contains a `<NetStandardImplicitPackageVersion>` entry. This entry points to version 1.0.0 which is not available on [nuget.org](https://www.nuget.org/packages/NETStandard.Library/). This PR removes the wrong entry and also fixes some other issues.